### PR TITLE
docs: add Skills.sh AI Skill page and register route

### DIFF
--- a/content/skills-sh.mdx
+++ b/content/skills-sh.mdx
@@ -1,0 +1,38 @@
+# Skills.sh AI Skill
+
+[Skills.sh](https://skills.sh) is an AI-powered skill platform that lets you build and share
+reusable autonomous skills — capabilities that an AI agent executes on demand, complete with
+context, instructions, and tool access.
+
+A **TypeComposer AI Skill** is available on Skills.sh. It equips the agent with knowledge
+of the TypeComposer framework, its zero-HTML TypeScript architecture, the roadmap, and the
+full repository ecosystem so that it can:
+
+- Answer questions about TypeComposer APIs and patterns
+- Review and open pull requests across the TypeComposer repos
+- Update documentation and tests in alignment with the roadmap
+- Investigate issues in the `plugin`, `create`, `ssr`, and `language-service` repos
+- Respond to maintainer feedback on open PRs
+
+## Using the Skill
+
+1. Visit [skills.sh](https://skills.sh) and search for **TypeComposer Framework Contributor**.
+2. Add it to your AI agent or workspace.
+3. Ask it anything about TypeComposer — from "How do I scaffold a new project?" to
+   "Open a PR that adds a render-utility test to the component testing baseline."
+
+## Why Skills.sh?
+
+Skills.sh stores skills as reusable, versioned units of AI behaviour. Each skill carries
+its own instructions, reference material, and tool list, making it easy for contributors
+to collaborate with an AI agent that already understands the TypeComposer codebase.
+
+## Contributing
+
+If you improve a skill or find a gap in the TypeComposer knowledge base, open an issue or
+PR in this repository. We'll keep the skill content in sync with new releases.
+
+---
+
+_This page is maintained by the TypeComposer community. For framework questions start at
+[Why TypeComposer?](docs/home) or jump into [Getting Started](docs/getting-started)._

--- a/content/skills-sh.mdx
+++ b/content/skills-sh.mdx
@@ -1,38 +1,53 @@
-# Skills.sh AI Skill
+# Agent Skills
 
-[Skills.sh](https://skills.sh) is an AI-powered skill platform that lets you build and share
-reusable autonomous skills — capabilities that an AI agent executes on demand, complete with
-context, instructions, and tool access.
+Agent skills for building TypeComposer apps directly from your AI coding assistant.
 
-A **TypeComposer AI Skill** is available on Skills.sh. It equips the agent with knowledge
-of the TypeComposer framework, its zero-HTML TypeScript architecture, the roadmap, and the
-full repository ecosystem so that it can:
+## What are agent skills?
 
-- Answer questions about TypeComposer APIs and patterns
-- Review and open pull requests across the TypeComposer repos
-- Update documentation and tests in alignment with the roadmap
-- Investigate issues in the `plugin`, `create`, `ssr`, and `language-service` repos
-- Respond to maintainer feedback on open PRs
+Agent Skills are an open format for extending AI coding assistants with specialised knowledge
+and capabilities. They follow the [Agent Skills](https://agentskills.io) specification.
 
-## Using the Skill
+Skills are markdown files (`SKILL.md`) that contain step-by-step instructions for an AI
+agent. When you ask your assistant something like "scaffold a TypeComposer component" or
+"open a PR to add a reactivity test," the agent selects the matching skill and follows its
+instructions automatically.
 
-1. Visit [skills.sh](https://skills.sh) and search for **TypeComposer Framework Contributor**.
-2. Add it to your AI agent or workspace.
-3. Ask it anything about TypeComposer — from "How do I scaffold a new project?" to
-   "Open a PR that adds a render-utility test to the component testing baseline."
+### Supported tools
 
-## Why Skills.sh?
+The TypeComposer skill works with any Agent Skills-compatible AI coding assistant, including
+Claude Code, OpenAI Codex, Cursor, and other tools that support the specification.
 
-Skills.sh stores skills as reusable, versioned units of AI behaviour. Each skill carries
-its own instructions, reference material, and tool list, making it easy for contributors
-to collaborate with an AI agent that already understands the TypeComposer codebase.
+## Installation
 
-## Contributing
+Install the TypeComposer skill with a single command:
 
-If you improve a skill or find a gap in the TypeComposer knowledge base, open an issue or
-PR in this repository. We'll keep the skill content in sync with new releases.
+```bash
+npx skills add TypeComposer/skill
+```
 
----
+This registers the skill with your AI assistant and makes the TypeComposer knowledge base
+available in your current workspace.
 
-_This page is maintained by the TypeComposer community. For framework questions start at
-[Why TypeComposer?](docs/home) or jump into [Getting Started](docs/getting-started)._
+## The TypeComposer skill
+
+The repository ships one skill: **TypeComposer Framework Contributor**. It follows a
+route-first design — your intent is matched to the correct repo and workflow, then
+execution details are resolved from structured reference files.
+
+### Workflow coverage
+
+| Task | Coverage |
+|---|---|
+| Scaffold a new project or library | ✓ |
+| Create or update components using the zero-HTML TypeScript model | ✓ |
+| Review and open pull requests (framework, docs, plugin, SSR, create) | ✓ |
+| Update documentation pages and MDX content | ✓ |
+| Add or fix Vitest tests against the component testing baseline | ✓ |
+| Investigate issues in `plugin`, `create`, `ssr`, or `language-service` | ✓ |
+| Respond to maintainer feedback on open PRs | ✓ |
+| Align changes with the TypeComposer roadmap | ✓ |
+
+## Source
+
+The TypeComposer agent skill is open-source and available on
+[GitHub](https://github.com/TypeComposer/skill).

--- a/src/assets/data.json
+++ b/src/assets/data.json
@@ -10,6 +10,10 @@
         {
           "title": "Getting Started",
           "link": "docs/getting-started"
+        },
+        {
+          "title": "Skills.sh AI Skill",
+          "link": "docs/skills-sh"
         }
       ]
     },

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -15,6 +15,7 @@ loadDocs().finally(() => {
         component: AppPage,
         children: [
           { path: "getting-started", component: BaseView },
+          { path: "skills-sh", component: BaseView },
           { path: "components/component", component: BaseView },
           { path: "components/template", component: BaseView },
           { path: "components/lifecycle-docs", component: BaseView },


### PR DESCRIPTION
## Summary

Adds documentation for the **TypeComposer Agent Skill** on Skills.sh and wires it into the sidebar navigation and router.

### Files changed

| File | Change |
|---|---|
| `content/skills-sh.mdx` | **New / rewritten** — Agent Skills documentation page (Railway-style structure) |
| `src/assets/data.json` | Insert `"Skills.sh AI Skill"` immediately after `"Getting Started"` in the Introduction section |
| `src/router/router.ts` | Add `{ path: "skills-sh", component: BaseView }` child route under `/docs` |

### What the Skills.sh page covers (after rewrite)

The page follows the concise, section-driven layout of Railway's Agent Skills docs:

- **What are agent skills?** — open format, agentskills.io spec, SKILL.md mechanics
- **Supported tools** — Claude Code, OpenAI Codex, Cursor, and other Agent Skills-compatible tools (generic, no overclaiming)
- **Installation** — exact `npx skills add TypeComposer/skill` command
- **The TypeComposer skill** — route-first design, what it knows about the framework
- **Workflow coverage** — table of every supported task (scaffold, component model, PRs, docs, tests, SSR/plugin investigation, roadmap alignment)
- **Source** — link to the open-source GitHub repo

### Roadmap alignment

**Docs / Release 1.0** — community tooling and contributor resources.

### Validation

```
npm install   ✅  (clean, no blocking errors)
npm run build ✅  vite build — ✓ 2404 modules transformed, built in 11.00s, exit 0
```

Only advisory warnings (chunk size hint, browser data age) — no errors.

### Reviewer

@zico15 — please review when you get a chance. Happy to adjust copy or sidebar placement based on your preferences.