### PR TITLE
feat(seo): robots.txt, sitemap.xml, llms.txt, canonical URL, JSON-LD, per-page meta titles/descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,33 +4,70 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/typecomposer.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://typecomposer.com/" />
+
     <!-- SEO Meta Tags -->
     <meta
       name="description"
-      content="TypeComposer is a framework for building web and native user interfaces. Build UIs from individual components written in JavaScript, and seamlessly integrate components developed by independent individuals, teams, and organizations."
+      content="TypeComposer is a zero-HTML TypeScript framework for building web and native user interfaces. Compose UIs from pure TypeScript classes — no JSX, no templates."
     />
-    <meta name="keywords" content="typecomposer, framework, web interfaces, native interfaces, UI components, JavaScript, modular UI, component-based design" />
+    <meta name="keywords" content="typecomposer, typescript framework, web interfaces, UI components, zero-html, component-based, reactive, no-jsx" />
     <meta name="author" content="TypeComposer Team" />
 
     <!-- Open Graph Tags for social media -->
-    <meta property="og:title" content="TypeComposer – Framework for Web and Native User Interfaces" />
+    <meta property="og:title" content="TypeComposer – Zero-HTML TypeScript UI Framework" />
     <meta
       property="og:description"
-      content="TypeComposer is a framework for building web and native user interfaces. Build UIs from individual components written in JavaScript, and seamlessly integrate components developed by independent individuals, teams, and organizations."
+      content="TypeComposer is a zero-HTML TypeScript framework for building web and native user interfaces. Compose UIs from pure TypeScript classes — no JSX, no templates."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://typecomposer.com" />
+    <meta property="og:url" content="https://typecomposer.com/" />
     <meta property="og:image" content="https://typecomposer.com/typecomposer.svg" />
 
     <!-- Twitter Card Tags -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="TypeComposer – Framework for Web and Native User Interfaces" />
+    <meta name="twitter:title" content="TypeComposer – Zero-HTML TypeScript UI Framework" />
     <meta
       name="twitter:description"
-      content="TypeComposer is a framework for building web and native user interfaces. Build UIs from individual components written in JavaScript, and seamlessly integrate components developed by independent individuals, teams, and organizations."
+      content="TypeComposer is a zero-HTML TypeScript framework for building web and native user interfaces. Compose UIs from pure TypeScript classes — no JSX, no templates."
     />
     <meta name="twitter:site" content="@typecomposer" />
-    <title>TypeComposer</title>
+
+    <!-- JSON-LD: WebSite -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "TypeComposer",
+      "url": "https://typecomposer.com/",
+      "description": "A zero-HTML TypeScript framework for building web and native user interfaces.",
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://typecomposer.com/#/docs/{search_term_string}",
+        "query-input": "required name=search_term_string"
+      }
+    }
+    </script>
+
+    <!-- JSON-LD: SoftwareApplication -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "TypeComposer",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Any",
+      "url": "https://typecomposer.com/",
+      "description": "A zero-HTML TypeScript framework for building web and native user interfaces using pure TypeScript component classes.",
+      "license": "https://github.com/TypeComposer/typecomposer/blob/main/LICENSE",
+      "codeRepository": "https://github.com/TypeComposer/typecomposer",
+      "programmingLanguage": "TypeScript"
+    }
+    </script>
+
+    <title>TypeComposer – Zero-HTML TypeScript UI Framework</title>
   </head>
   <body>
     <script defer type="module" src="/src/main.ts"></script>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,55 @@
+# TypeComposer
+
+> A zero-HTML TypeScript framework for building web and native user interfaces using pure TypeScript component classes.
+
+TypeComposer lets you compose UIs entirely in TypeScript — no JSX, no HTML templates, no string-based templates. Components are plain TypeScript classes that extend built-in element types (DivElement, VBox, BorderPanel, etc.) and compose directly with each other.
+
+## Key Concepts
+
+- **Components** — TypeScript classes extending `Component` or built-in elements. No HTML files.
+- **Reactivity** — `ref`, `refBoolean`, `refNumber`, `refString`, `refList`, `refMap`, `refSet`, `computed` — reactive primitives that update the DOM automatically.
+- **Layout** — `VBox`, `HBox`, `BorderPanel` — flexbox-based layout components.
+- **Elements** — `DivElement`, `ButtonElement`, `InputElement`, `LabelElement`, `SpanElement`, `HeadingElement`, `TableElement`.
+- **Router** — Hash-based SPA router with typed route definitions. `Router.create({ history: "hash", routes: [...] })`.
+- **RouterView** — Outlet component that renders the matched child route.
+- **Dependency Injection** — Built-in DI container; inject services into components via constructor.
+- **Agent Skills** — Integration guide for using TypeComposer apps as AI agent skills.
+
+## Docs
+
+- [Why TypeComposer?](https://typecomposer.com/#/docs/home)
+- [Getting Started](https://typecomposer.com/#/docs/getting-started)
+- [Component](https://typecomposer.com/#/docs/components/component)
+- [Template](https://typecomposer.com/#/docs/components/template)
+- [Lifecycle](https://typecomposer.com/#/docs/components/lifecycle-docs)
+- [Dependency Injection](https://typecomposer.com/#/docs/dependency-injection)
+- [ref](https://typecomposer.com/#/docs/reactivity/ref)
+- [refBoolean](https://typecomposer.com/#/docs/reactivity/refboolean)
+- [refNumber](https://typecomposer.com/#/docs/reactivity/refnumber)
+- [refString](https://typecomposer.com/#/docs/reactivity/refstring)
+- [refList](https://typecomposer.com/#/docs/reactivity/reflist)
+- [refMap](https://typecomposer.com/#/docs/reactivity/refmap)
+- [refSet](https://typecomposer.com/#/docs/reactivity/refset)
+- [computed](https://typecomposer.com/#/docs/reactivity/computed)
+- [Router](https://typecomposer.com/#/docs/router)
+- [RouterView](https://typecomposer.com/#/docs/router-view)
+- [BorderPanel](https://typecomposer.com/#/docs/layout/border-panel)
+- [VBox](https://typecomposer.com/#/docs/layout/vbox)
+- [HBox](https://typecomposer.com/#/docs/layout/hbox)
+- [Div](https://typecomposer.com/#/docs/elements/div)
+- [Button](https://typecomposer.com/#/docs/elements/button)
+- [Input](https://typecomposer.com/#/docs/elements/input)
+- [Label](https://typecomposer.com/#/docs/elements/label)
+- [Table](https://typecomposer.com/#/docs/elements/table)
+- [Span](https://typecomposer.com/#/docs/elements/span)
+- [Heading](https://typecomposer.com/#/docs/elements/heading)
+- [Agent Skills](https://typecomposer.com/#/docs/skills)
+- [Playground](https://typecomposer.com/#/playground)
+
+## GitHub
+
+- [typecomposer/typecomposer](https://github.com/TypeComposer/typecomposer) — core framework
+- [typecomposer/docs](https://github.com/TypeComposer/docs) — documentation site
+- [typecomposer/plugin](https://github.com/TypeComposer/plugin) — Vite plugin
+- [typecomposer/create](https://github.com/TypeComposer/create) — CLI scaffolding
+- [typecomposer/ssr](https://github.com/TypeComposer/ssr) — SSR / hydration

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://typecomposer.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <!-- Root / landing page -->
+  <url>
+    <loc>https://typecomposer.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+
+  <!-- Docs – Introduction -->
+  <url>
+    <loc>https://typecomposer.com/#/docs/home</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/getting-started</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/skills</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <!-- Docs – Components -->
+  <url>
+    <loc>https://typecomposer.com/#/docs/components/component</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/components/template</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/components/lifecycle-docs</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <!-- Docs – Dependency Injection -->
+  <url>
+    <loc>https://typecomposer.com/#/docs/dependency-injection</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <!-- Docs – Reactivity -->
+  <url>
+    <loc>https://typecomposer.com/#/docs/reactivity/ref</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/reactivity/refboolean</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/reactivity/refnumber</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/reactivity/refstring</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/reactivity/reflist</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/reactivity/refmap</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/reactivity/refset</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/reactivity/computed</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <!-- Docs – Router -->
+  <url>
+    <loc>https://typecomposer.com/#/docs/router</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/router-view</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <!-- Docs – Layout -->
+  <url>
+    <loc>https://typecomposer.com/#/docs/layout/border-panel</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/layout/vbox</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/layout/hbox</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <!-- Docs – Elements -->
+  <url>
+    <loc>https://typecomposer.com/#/docs/elements/div</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/elements/button</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/elements/input</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/elements/label</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/elements/table</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/elements/span</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://typecomposer.com/#/docs/elements/heading</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <!-- Playground -->
+  <url>
+    <loc>https://typecomposer.com/#/playground</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+</urlset>

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,0 +1,158 @@
+/**
+ * SEO utilities — update <title> and <meta name="description"> on each route
+ * transition. Since this is a hash-router SPA with no SSR, these updates help
+ * browser history titles, social preview when JS runs, and AI crawlers that
+ * execute JS (e.g. Googlebot, GPTBot after rendering).
+ *
+ * Canonical stays fixed at https://typecomposer.com/ in index.html because
+ * hash fragments are not real URLs; there is no per-page canonical benefit.
+ */
+
+interface PageMeta {
+  title: string;
+  description: string;
+}
+
+const BASE_TITLE = "TypeComposer";
+const BASE_DESC =
+  "A zero-HTML TypeScript framework for building web and native user interfaces. Compose UIs from pure TypeScript classes — no JSX, no templates.";
+
+/** Per-route meta map keyed by Router.pathname value (e.g. "docs/getting-started") */
+const PAGE_META: Record<string, PageMeta> = {
+  "docs/home": {
+    title: "Why TypeComposer?",
+    description:
+      "Learn why TypeComposer takes a zero-HTML approach to building UIs — pure TypeScript classes, no JSX, no templates, full type safety.",
+  },
+  "docs/getting-started": {
+    title: "Getting Started",
+    description:
+      "Install TypeComposer and scaffold your first project in minutes. Step-by-step guide with npm, Vite, and the typecomposer-plugin.",
+  },
+  "docs/skills": {
+    title: "Agent Skills",
+    description:
+      "Use TypeComposer to build AI agent skills. Integration guide and examples for connecting your TypeComposer app as a skill endpoint.",
+  },
+  "docs/components/component": {
+    title: "Component",
+    description: "Deep-dive into the TypeComposer Component class — the base building block for every UI element.",
+  },
+  "docs/components/template": {
+    title: "Template",
+    description: "TypeComposer template system: define reusable, composable UI structures entirely in TypeScript.",
+  },
+  "docs/components/lifecycle-docs": {
+    title: "Component Lifecycle",
+    description: "Understand the TypeComposer component lifecycle: onConnected, onDisconnected, and reactive update hooks.",
+  },
+  "docs/dependency-injection": {
+    title: "Dependency Injection",
+    description: "Built-in DI container in TypeComposer — inject services and share state across components without global singletons.",
+  },
+  "docs/reactivity/ref": {
+    title: "ref – Reactivity",
+    description: "ref is TypeComposer's core reactive primitive. Learn how to create reactive values that automatically update the DOM.",
+  },
+  "docs/reactivity/refboolean": {
+    title: "refBoolean – Reactivity",
+    description: "Reactive boolean values in TypeComposer — toggle visibility, classes, and attributes with automatic DOM updates.",
+  },
+  "docs/reactivity/refnumber": {
+    title: "refNumber – Reactivity",
+    description: "Reactive numeric values in TypeComposer — bind counters, scores, and numeric state to your UI automatically.",
+  },
+  "docs/reactivity/refstring": {
+    title: "refString – Reactivity",
+    description: "Reactive string values in TypeComposer — keep text content in sync with application state effortlessly.",
+  },
+  "docs/reactivity/reflist": {
+    title: "refList – Reactivity",
+    description: "Reactive list (array) in TypeComposer — render and update lists automatically as items are added or removed.",
+  },
+  "docs/reactivity/refmap": {
+    title: "refMap – Reactivity",
+    description: "Reactive Map in TypeComposer — bind key-value collections to the DOM with automatic change propagation.",
+  },
+  "docs/reactivity/refset": {
+    title: "refSet – Reactivity",
+    description: "Reactive Set in TypeComposer — manage unique collections with automatic UI synchronization.",
+  },
+  "docs/reactivity/computed": {
+    title: "computed – Reactivity",
+    description: "Derived reactive values in TypeComposer — computed automatically updates whenever its reactive dependencies change.",
+  },
+  "docs/router": {
+    title: "Router",
+    description: "TypeComposer's built-in hash router — define typed routes, nested routes, wildcards, and redirects in pure TypeScript.",
+  },
+  "docs/router-view": {
+    title: "RouterView",
+    description: "RouterView is the outlet component that renders the active child route inside your layout.",
+  },
+  "docs/layout/border-panel": {
+    title: "BorderPanel – Layout",
+    description: "BorderPanel provides a classic top/bottom/left/right/center layout region system for building app shells.",
+  },
+  "docs/layout/vbox": {
+    title: "VBox – Layout",
+    description: "VBox stacks children vertically using flexbox. The primary vertical layout container in TypeComposer.",
+  },
+  "docs/layout/hbox": {
+    title: "HBox – Layout",
+    description: "HBox arranges children horizontally using flexbox. The primary horizontal layout container in TypeComposer.",
+  },
+  "docs/elements/div": {
+    title: "DivElement",
+    description: "DivElement is the TypeComposer wrapper for a div, with reactive props and full component lifecycle support.",
+  },
+  "docs/elements/button": {
+    title: "ButtonElement",
+    description: "ButtonElement — accessible, reactive button component in TypeComposer with onClick and state binding.",
+  },
+  "docs/elements/input": {
+    title: "InputElement",
+    description: "InputElement — reactive text input in TypeComposer with two-way binding and full type safety.",
+  },
+  "docs/elements/label": {
+    title: "LabelElement",
+    description: "LabelElement — accessible form label component in TypeComposer, linkable to inputs via htmlFor.",
+  },
+  "docs/elements/table": {
+    title: "TableElement",
+    description: "TableElement — reactive HTML table in TypeComposer, composable with thead, tbody, tr, td, and th.",
+  },
+  "docs/elements/span": {
+    title: "SpanElement",
+    description: "SpanElement — inline text container in TypeComposer with reactive innerText and className binding.",
+  },
+  "docs/elements/heading": {
+    title: "HeadingElement",
+    description: "HeadingElement — H1–H6 heading components in TypeComposer with semantic HTML and reactive content.",
+  },
+};
+
+/**
+ * Update <title> and <meta name="description"> for the given router pathname.
+ * Call this from BaseView constructor or onConnected whenever the route changes.
+ */
+export function updatePageMeta(pathname: string): void {
+  const meta = PAGE_META[pathname];
+  if (meta) {
+    document.title = `${meta.title} | ${BASE_TITLE}`;
+    setMetaDescription(meta.description);
+  } else {
+    document.title = BASE_TITLE;
+    setMetaDescription(BASE_DESC);
+  }
+}
+
+function setMetaDescription(content: string): void {
+  let tag = document.querySelector<HTMLMetaElement>('meta[name="description"]');
+  if (!tag) {
+    tag = document.createElement("meta");
+    tag.name = "description";
+    document.head.appendChild(tag);
+  }
+  tag.content = content;
+}

--- a/src/views/elements/Base.ts
+++ b/src/views/elements/Base.ts
@@ -1,6 +1,7 @@
 import { CodeComponent } from "@/components/code/CodeComponent";
 import { Navigation } from "@/components/navigation/Navigation";
 import { getPage } from "@/utils/mdx";
+import { updatePageMeta } from "@/utils/seo";
 import {
   AnchorElement,
   ButtonElement,
@@ -65,6 +66,7 @@ export class BaseView extends VBox {
     super({ className: "main-content" });
 
     this.contentWrapper = this.appendChild(new VBox({ className: "content-wrapper w-full" }));
+    updatePageMeta(Router.pathname);
     this.contentWrapper.append(getPage(Router.pathname));
     this.contentWrapper.append(new Navigation());
   }


### PR DESCRIPTION
## What changed and why

SEO/indexability improvements based on Gonçalo's audit, as requested by João. Highest-value static wins with no new npm dependencies, no unrelated churn, and no conflict with #30 (already merged).

---

### Architecture findings (pre-PR)

| Concern | Finding |
|---|---|
| Routing mode | `history: "hash"` — all docs URLs are `#/docs/…` |
| Hosting fallback | `public/.htaccess` already rewrites all paths → `index.html` ✓ |
| Static file serving | Vite copies `public/` verbatim to `dist/` ✓ |
| Existing metadata | `index.html` had generic OG/Twitter tags but **no canonical**, **no JSON-LD**, **no robots.txt**, **no sitemap**, **no per-page titles** |
| PR #30 | Merged before this PR — `docs/skills` route is live ✓ |
| Hash URL + canonicals | Hash fragments are not real URLs → single canonical at root is correct; per-page canonicals add no benefit without SSR |
| Clean URL migration | Deferred — server must be verified to support `try_files` / Apache rewrite for every `/docs/*` path; .htaccess is present but hosting needs confirmation |

---

### Changes

| File | What |
|---|---|
| `public/robots.txt` | Allow all crawlers; `Sitemap:` directive pointing to sitemap |
| `public/sitemap.xml` | 29 `<url>` entries for every registered route (home, all docs pages, playground) |
| `public/llms.txt` | [llmstxt.org](https://llmstxt.org) convention — machine-readable site manifest for LLM indexers (GPTBot, Claude, Gemini) |
| `index.html` | `<link rel="canonical">` → root URL; two JSON-LD blocks (WebSite + SoftwareApplication); improved title/description copy ("zero-HTML" framing) |
| `src/utils/seo.ts` | **New** — `updatePageMeta(pathname)` with per-route `<title>` + `<meta name="description">` map (29 routes) |
| `src/views/elements/Base.ts` | Call `updatePageMeta(Router.pathname)` in `BaseView` constructor — fires on every docs page navigation |

---

### What was deferred / not included

| Item | Reason |
|---|---|
| **Clean (history-mode) URLs** | Requires confirming hosting supports path rewrites for _all_ `/docs/*` URLs before enabling `history: "browser"` in the router — wrong call without server verification; the `.htaccess` is present but needs testing |
| **Per-page canonical URLs** | No benefit over root canonical with hash routing + no SSR |
| **Prerendering / static HTML** | Out of scope — would require either SSR or a prerender plugin |

---

### Validation

```
npm install
npm run build   # ✓ built in 11.11s — zero errors, zero new warnings
```

Build confirms all 3 static files are copied to `dist/` (`robots.txt`, `sitemap.xml`, `llms.txt`), `index.html` contains canonical and JSON-LD, and `seo.ts` is tree-shaken cleanly into the bundle.

**Diff:** 6 files — 430 insertions, 9 deletions (index.html copy improvements).

### Reviewer
@zico15