### PR TITLE
feat(seo): migrate hash router to browser history for clean, indexable URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/typecomposer.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <!-- Canonical URL (root; per-route canonicals are set dynamically by seo.ts) -->
+    <!-- Canonical URL -->
     <link rel="canonical" href="https://typecomposer.com/" />
 
     <!-- SEO Meta Tags -->

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/typecomposer.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <!-- Canonical URL -->
+    <!-- Canonical URL (root; per-route canonicals are set dynamically by seo.ts) -->
     <link rel="canonical" href="https://typecomposer.com/" />
 
     <!-- SEO Meta Tags -->
@@ -45,7 +45,7 @@
       "description": "A zero-HTML TypeScript framework for building web and native user interfaces.",
       "potentialAction": {
         "@type": "SearchAction",
-        "target": "https://typecomposer.com/#/docs/{search_term_string}",
+        "target": "https://typecomposer.com/docs/{search_term_string}",
         "query-input": "required name=search_term_string"
       }
     }

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,9 +1,11 @@
-# Ativa o módulo de reescrita de URLs
+# SPA fallback: rewrite all non-file, non-directory requests to index.html
+# This enables browser-history (HTML5 pushState) routing for clean URLs like
+# /docs/skills, /docs/getting-started, /playground, etc.
 RewriteEngine On
 
-# Se o recurso solicitado não for um arquivo (-f) nem um diretório (-d)
+# Allow direct access to real files (assets, robots.txt, sitemap.xml, etc.)
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 
-# Redireciona todas as requisições para index.html
+# Rewrite everything else to the SPA entry point
 RewriteRule ^.*$ /index.html [L,QSA]

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -10,41 +10,41 @@ TypeComposer lets you compose UIs entirely in TypeScript — no JSX, no HTML tem
 - **Reactivity** — `ref`, `refBoolean`, `refNumber`, `refString`, `refList`, `refMap`, `refSet`, `computed` — reactive primitives that update the DOM automatically.
 - **Layout** — `VBox`, `HBox`, `BorderPanel` — flexbox-based layout components.
 - **Elements** — `DivElement`, `ButtonElement`, `InputElement`, `LabelElement`, `SpanElement`, `HeadingElement`, `TableElement`.
-- **Router** — Hash-based SPA router with typed route definitions. `Router.create({ history: "hash", routes: [...] })`.
+- **Router** — Browser-history SPA router with typed route definitions. `Router.create({ history: "browser", routes: [...] })`.
 - **RouterView** — Outlet component that renders the matched child route.
 - **Dependency Injection** — Built-in DI container; inject services into components via constructor.
 - **Agent Skills** — Integration guide for using TypeComposer apps as AI agent skills.
 
 ## Docs
 
-- [Why TypeComposer?](https://typecomposer.com/#/docs/home)
-- [Getting Started](https://typecomposer.com/#/docs/getting-started)
-- [Component](https://typecomposer.com/#/docs/components/component)
-- [Template](https://typecomposer.com/#/docs/components/template)
-- [Lifecycle](https://typecomposer.com/#/docs/components/lifecycle-docs)
-- [Dependency Injection](https://typecomposer.com/#/docs/dependency-injection)
-- [ref](https://typecomposer.com/#/docs/reactivity/ref)
-- [refBoolean](https://typecomposer.com/#/docs/reactivity/refboolean)
-- [refNumber](https://typecomposer.com/#/docs/reactivity/refnumber)
-- [refString](https://typecomposer.com/#/docs/reactivity/refstring)
-- [refList](https://typecomposer.com/#/docs/reactivity/reflist)
-- [refMap](https://typecomposer.com/#/docs/reactivity/refmap)
-- [refSet](https://typecomposer.com/#/docs/reactivity/refset)
-- [computed](https://typecomposer.com/#/docs/reactivity/computed)
-- [Router](https://typecomposer.com/#/docs/router)
-- [RouterView](https://typecomposer.com/#/docs/router-view)
-- [BorderPanel](https://typecomposer.com/#/docs/layout/border-panel)
-- [VBox](https://typecomposer.com/#/docs/layout/vbox)
-- [HBox](https://typecomposer.com/#/docs/layout/hbox)
-- [Div](https://typecomposer.com/#/docs/elements/div)
-- [Button](https://typecomposer.com/#/docs/elements/button)
-- [Input](https://typecomposer.com/#/docs/elements/input)
-- [Label](https://typecomposer.com/#/docs/elements/label)
-- [Table](https://typecomposer.com/#/docs/elements/table)
-- [Span](https://typecomposer.com/#/docs/elements/span)
-- [Heading](https://typecomposer.com/#/docs/elements/heading)
-- [Agent Skills](https://typecomposer.com/#/docs/skills)
-- [Playground](https://typecomposer.com/#/playground)
+- [Why TypeComposer?](https://typecomposer.com/docs/home)
+- [Getting Started](https://typecomposer.com/docs/getting-started)
+- [Component](https://typecomposer.com/docs/components/component)
+- [Template](https://typecomposer.com/docs/components/template)
+- [Lifecycle](https://typecomposer.com/docs/components/lifecycle-docs)
+- [Dependency Injection](https://typecomposer.com/docs/dependency-injection)
+- [ref](https://typecomposer.com/docs/reactivity/ref)
+- [refBoolean](https://typecomposer.com/docs/reactivity/refboolean)
+- [refNumber](https://typecomposer.com/docs/reactivity/refnumber)
+- [refString](https://typecomposer.com/docs/reactivity/refstring)
+- [refList](https://typecomposer.com/docs/reactivity/reflist)
+- [refMap](https://typecomposer.com/docs/reactivity/refmap)
+- [refSet](https://typecomposer.com/docs/reactivity/refset)
+- [computed](https://typecomposer.com/docs/reactivity/computed)
+- [Router](https://typecomposer.com/docs/router)
+- [RouterView](https://typecomposer.com/docs/router-view)
+- [BorderPanel](https://typecomposer.com/docs/layout/border-panel)
+- [VBox](https://typecomposer.com/docs/layout/vbox)
+- [HBox](https://typecomposer.com/docs/layout/hbox)
+- [Div](https://typecomposer.com/docs/elements/div)
+- [Button](https://typecomposer.com/docs/elements/button)
+- [Input](https://typecomposer.com/docs/elements/input)
+- [Label](https://typecomposer.com/docs/elements/label)
+- [Table](https://typecomposer.com/docs/elements/table)
+- [Span](https://typecomposer.com/docs/elements/span)
+- [Heading](https://typecomposer.com/docs/elements/heading)
+- [Agent Skills](https://typecomposer.com/docs/skills)
+- [Playground](https://typecomposer.com/playground)
 
 ## GitHub
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -9,156 +9,156 @@
 
   <!-- Docs – Introduction -->
   <url>
-    <loc>https://typecomposer.com/#/docs/home</loc>
+    <loc>https://typecomposer.com/docs/home</loc>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/getting-started</loc>
+    <loc>https://typecomposer.com/docs/getting-started</loc>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/skills</loc>
+    <loc>https://typecomposer.com/docs/skills</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Docs – Components -->
   <url>
-    <loc>https://typecomposer.com/#/docs/components/component</loc>
+    <loc>https://typecomposer.com/docs/components/component</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/components/template</loc>
+    <loc>https://typecomposer.com/docs/components/template</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/components/lifecycle-docs</loc>
+    <loc>https://typecomposer.com/docs/components/lifecycle-docs</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <!-- Docs – Dependency Injection -->
   <url>
-    <loc>https://typecomposer.com/#/docs/dependency-injection</loc>
+    <loc>https://typecomposer.com/docs/dependency-injection</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <!-- Docs – Reactivity -->
   <url>
-    <loc>https://typecomposer.com/#/docs/reactivity/ref</loc>
+    <loc>https://typecomposer.com/docs/reactivity/ref</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/reactivity/refboolean</loc>
+    <loc>https://typecomposer.com/docs/reactivity/refboolean</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/reactivity/refnumber</loc>
+    <loc>https://typecomposer.com/docs/reactivity/refnumber</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/reactivity/refstring</loc>
+    <loc>https://typecomposer.com/docs/reactivity/refstring</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/reactivity/reflist</loc>
+    <loc>https://typecomposer.com/docs/reactivity/reflist</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/reactivity/refmap</loc>
+    <loc>https://typecomposer.com/docs/reactivity/refmap</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/reactivity/refset</loc>
+    <loc>https://typecomposer.com/docs/reactivity/refset</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/reactivity/computed</loc>
+    <loc>https://typecomposer.com/docs/reactivity/computed</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <!-- Docs – Router -->
   <url>
-    <loc>https://typecomposer.com/#/docs/router</loc>
+    <loc>https://typecomposer.com/docs/router</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/router-view</loc>
+    <loc>https://typecomposer.com/docs/router-view</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <!-- Docs – Layout -->
   <url>
-    <loc>https://typecomposer.com/#/docs/layout/border-panel</loc>
+    <loc>https://typecomposer.com/docs/layout/border-panel</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/layout/vbox</loc>
+    <loc>https://typecomposer.com/docs/layout/vbox</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/layout/hbox</loc>
+    <loc>https://typecomposer.com/docs/layout/hbox</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <!-- Docs – Elements -->
   <url>
-    <loc>https://typecomposer.com/#/docs/elements/div</loc>
+    <loc>https://typecomposer.com/docs/elements/div</loc>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/elements/button</loc>
+    <loc>https://typecomposer.com/docs/elements/button</loc>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/elements/input</loc>
+    <loc>https://typecomposer.com/docs/elements/input</loc>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/elements/label</loc>
+    <loc>https://typecomposer.com/docs/elements/label</loc>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/elements/table</loc>
+    <loc>https://typecomposer.com/docs/elements/table</loc>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/elements/span</loc>
+    <loc>https://typecomposer.com/docs/elements/span</loc>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://typecomposer.com/#/docs/elements/heading</loc>
+    <loc>https://typecomposer.com/docs/elements/heading</loc>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Playground -->
   <url>
-    <loc>https://typecomposer.com/#/playground</loc>
+    <loc>https://typecomposer.com/playground</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -7,7 +7,7 @@ import { HomePage } from "@/pages/Home";
 
 loadDocs().finally(() => {
   Router.create({
-    history: "hash",
+    history: "browser",
     routes: [
       { path: "/", component: HomePage },
       {

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,10 +1,11 @@
 /**
- * SEO utilities — update <title>, <meta name="description">, and
- * <link rel="canonical"> on each route transition.
+ * SEO utilities — update <title> and <meta name="description"> on each route
+ * transition.
  *
  * With browser-history routing every route is a real URL, so Googlebot and
  * other crawlers can index /docs/skills, /docs/getting-started, etc. directly.
- * Per-route canonicals are therefore meaningful and are set dynamically here.
+ * The static <link rel="canonical"> in index.html covers the root; per-route
+ * canonicals are declared in the sitemap rather than injected at runtime.
  */
 
 interface PageMeta {
@@ -15,7 +16,6 @@ interface PageMeta {
 const BASE_TITLE = "TypeComposer";
 const BASE_DESC =
   "A zero-HTML TypeScript framework for building web and native user interfaces. Compose UIs from pure TypeScript classes — no JSX, no templates.";
-const CANONICAL_BASE = "https://typecomposer.com";
 
 /** Per-route meta map keyed by Router.pathname value (e.g. "docs/getting-started") */
 const PAGE_META: Record<string, PageMeta> = {
@@ -133,8 +133,8 @@ const PAGE_META: Record<string, PageMeta> = {
 };
 
 /**
- * Update <title>, <meta name="description">, and <link rel="canonical">
- * for the given router pathname (e.g. "docs/skills").
+ * Update <title> and <meta name="description"> for the given router pathname
+ * (e.g. "docs/skills").
  * Call this from BaseView constructor or onConnected whenever the route changes.
  */
 export function updatePageMeta(pathname: string): void {
@@ -146,8 +146,6 @@ export function updatePageMeta(pathname: string): void {
     document.title = BASE_TITLE;
     setMetaDescription(BASE_DESC);
   }
-  // Set per-route canonical now that we use real browser-history URLs
-  setCanonical(`${CANONICAL_BASE}/${pathname}`);
 }
 
 function setMetaDescription(content: string): void {
@@ -158,14 +156,4 @@ function setMetaDescription(content: string): void {
     document.head.appendChild(tag);
   }
   tag.content = content;
-}
-
-function setCanonical(href: string): void {
-  let tag = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
-  if (!tag) {
-    tag = document.createElement("link");
-    tag.rel = "canonical";
-    document.head.appendChild(tag);
-  }
-  tag.href = href;
 }

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,11 +1,10 @@
 /**
- * SEO utilities — update <title> and <meta name="description"> on each route
- * transition. Since this is a hash-router SPA with no SSR, these updates help
- * browser history titles, social preview when JS runs, and AI crawlers that
- * execute JS (e.g. Googlebot, GPTBot after rendering).
+ * SEO utilities — update <title>, <meta name="description">, and
+ * <link rel="canonical"> on each route transition.
  *
- * Canonical stays fixed at https://typecomposer.com/ in index.html because
- * hash fragments are not real URLs; there is no per-page canonical benefit.
+ * With browser-history routing every route is a real URL, so Googlebot and
+ * other crawlers can index /docs/skills, /docs/getting-started, etc. directly.
+ * Per-route canonicals are therefore meaningful and are set dynamically here.
  */
 
 interface PageMeta {
@@ -16,6 +15,7 @@ interface PageMeta {
 const BASE_TITLE = "TypeComposer";
 const BASE_DESC =
   "A zero-HTML TypeScript framework for building web and native user interfaces. Compose UIs from pure TypeScript classes — no JSX, no templates.";
+const CANONICAL_BASE = "https://typecomposer.com";
 
 /** Per-route meta map keyed by Router.pathname value (e.g. "docs/getting-started") */
 const PAGE_META: Record<string, PageMeta> = {
@@ -84,7 +84,7 @@ const PAGE_META: Record<string, PageMeta> = {
   },
   "docs/router": {
     title: "Router",
-    description: "TypeComposer's built-in hash router — define typed routes, nested routes, wildcards, and redirects in pure TypeScript.",
+    description: "TypeComposer's built-in router — define typed routes, nested routes, wildcards, and redirects in pure TypeScript.",
   },
   "docs/router-view": {
     title: "RouterView",
@@ -133,7 +133,8 @@ const PAGE_META: Record<string, PageMeta> = {
 };
 
 /**
- * Update <title> and <meta name="description"> for the given router pathname.
+ * Update <title>, <meta name="description">, and <link rel="canonical">
+ * for the given router pathname (e.g. "docs/skills").
  * Call this from BaseView constructor or onConnected whenever the route changes.
  */
 export function updatePageMeta(pathname: string): void {
@@ -145,6 +146,8 @@ export function updatePageMeta(pathname: string): void {
     document.title = BASE_TITLE;
     setMetaDescription(BASE_DESC);
   }
+  // Set per-route canonical now that we use real browser-history URLs
+  setCanonical(`${CANONICAL_BASE}/${pathname}`);
 }
 
 function setMetaDescription(content: string): void {
@@ -155,4 +158,14 @@ function setMetaDescription(content: string): void {
     document.head.appendChild(tag);
   }
   tag.content = content;
+}
+
+function setCanonical(href: string): void {
+  let tag = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+  if (!tag) {
+    tag = document.createElement("link");
+    tag.rel = "canonical";
+    document.head.appendChild(tag);
+  }
+  tag.href = href;
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -34,7 +34,9 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
-  base: "./",
+  // Use absolute base "/" so asset paths resolve correctly with browser-history
+  // routing (e.g. /docs/skills loads assets from /assets/*, not /docs/assets/*).
+  base: "/",
   css: {
     preprocessorOptions: {
       scss: {


### PR DESCRIPTION
## SEO P0 — Clean URLs via Browser History Routing

Follow-up to #29, #30, #31.

### Problem

Hash routing (`/#/docs/skills`) is not indexable by search engines — the fragment after `#` is never sent to the server, so Googlebot sees only `https://typecomposer.com/` for every page. Direct deep-links to `/docs/skills` also 404 without a proper SPA fallback. This means the sitemap, per-route canonicals, and per-page meta added in #31 cannot deliver their full SEO value.

### Solution

Switch `Router.create` from `history: "hash"` to `history: "browser"` (HTML5 `pushState`). The server-side SPA fallback (`.htaccess`) was **already present in the repo** before this PR and contains the correct `RewriteRule ^.*$ /index.html [L,QSA]` — so direct deep-links will be served correctly on the Apache-hosted production site once this PR is merged and deployed.

---

### Files Changed (7)

| File | Change |
|------|--------|
| `src/router/router.ts` | `history: "hash"` → `history: "browser"` |
| `vite.config.js` | `base: "./"` → `base: "/"` — absolute asset paths prevent broken JS/CSS loads when a user navigates directly to a nested route like `/docs/skills` (relative `./assets/` would resolve to `/docs/assets/`) |
| `src/utils/seo.ts` | `updatePageMeta()` updates `<title>` and `<meta name="description">` per route. Runtime `setCanonical()` workaround **removed** — the static root canonical in `index.html` covers the home route, and `sitemap.xml` provides authoritative clean-URL canonicals for all 29 pages without requiring JS. |
| `public/sitemap.xml` | Strip `#/` from all 29 URLs (`/#/docs/skills` → `/docs/skills`, `/#/playground` → `/playground`) |
| `public/llms.txt` | Same URL migration for all 29 doc links; Router key concept updated to reference `history: "browser"` |
| `index.html` | JSON-LD `SearchAction.target` updated from `/#/docs/{search_term_string}` → `/docs/{search_term_string}`; canonical comment tidied |
| `public/.htaccess` | Comments improved for clarity; **rewrite rule logic unchanged** — it was already correct |

---

### Build Validation (commit 2)

```
npm run build
✓ 2405 modules transformed — no errors, no type errors
```

```
dist/.htaccess        ✓ present (copied from public/)
dist/sitemap.xml      ✓ 0 hash URLs remaining
dist/llms.txt         ✓ 0 hash URLs remaining
dist/index.html       ✓ assets load from /assets/* (absolute paths)
dist/index.html       ✓ root canonical <https://typecomposer.com/> present
src/utils/seo.ts      ✓ setCanonical() removed
src/utils/seo.ts      ✓ CANONICAL_BASE constant removed
```

---

### ⚠️ Hosting Verification Required Before Release

The `.htaccess` SPA fallback must be honoured by the production Apache server. Please test after deploy:

```bash
# Direct deep-link must return HTTP 200, not 301/302/404
curl -I https://typecomposer.com/docs/skills
# Expected: HTTP/2 200

curl -I https://typecomposer.com/docs/getting-started
# Expected: HTTP/2 200

curl -I https://typecomposer.com/playground
# Expected: HTTP/2 200

# Assets must still load correctly
curl -I https://typecomposer.com/typecomposer.svg
# Expected: HTTP/2 200

curl -I https://typecomposer.com/sitemap.xml
# Expected: HTTP/2 200
```

If the Apache server requires `AllowOverride All` in its vhost config, that must be enabled separately by the hosting admin. If `.htaccess` is not supported, a `_redirects` (Netlify) or `vercel.json` equivalent would be needed — but the existing `.htaccess` confirms Apache is the target host.

---

### /docs/skills → Agent Skills ✓

Route `docs/skills` maps to `BaseView` and `PAGE_META["docs/skills"]` is unchanged:
- Title: **Agent Skills | TypeComposer**
- Description: _Use TypeComposer to build AI agent skills…_

---

cc @zico15