### PR TITLE
fix(playground): replace esm.sh with jsDelivr +esm — fixes HTTP 500 on core.mjs

### DIFF
--- a/src/views/playground/PlaygroundView.ts
+++ b/src/views/playground/PlaygroundView.ts
@@ -312,11 +312,15 @@ export class PlaygroundView extends Component {
 	 * Create HTML document for iframe.
 	 * The compiled user code is injected as a blob: URL and referenced via
 	 * a dynamic import() inside the iframe module script.
-	 * The import map resolves `typecomposer` to the esm.sh CDN — no text
-	 * replacement needed (and text replacement was fragile anyway).
+	 * The import map resolves `typecomposer` to the jsDelivr CDN (+esm single bundle).
+	 * esm.sh is broken for this package (HTTP 500 on its generated core.mjs due to
+	 * a circular re-export); jsDelivr bundles it correctly with Rollup.
 	 */
 	private createIframeHTML(compiledCode: string): string {
-		const typecomposerUrl = `https://esm.sh/typecomposer@${TYPECOMPOSER_VERSION}`;
+		// jsdelivr +esm bundles the package into a single ES module without the
+		// split-entry pattern that esm.sh uses — esm.sh@0.1.56 fails with HTTP 500
+		// on its generated core.mjs due to a circular re-export in the package.
+		const typecomposerUrl = `https://cdn.jsdelivr.net/npm/typecomposer@${TYPECOMPOSER_VERSION}/+esm`;
 
 		// Create a blob URL for the compiled user code.
 		// Tracked in pendingBlobUrls so it is revoked on the next compile run.


### PR DESCRIPTION
## Bug report (João)

```
GET https://esm.sh/typecomposer@0.1.56/es2022/core.mjs  net::ERR_ABORTED 500
[Playground] Initialization failed: TypeError: Failed to fetch dynamically imported module:
  https://esm.sh/typecomposer@0.1.56
```

---

## Root cause

`esm.sh` auto-generates a **split-entry bundle** for `typecomposer@0.1.56`:

```js
// https://esm.sh/typecomposer@0.1.56  ← 200, but…
import "/typecomposer@0.1.56/es2022/core.mjs";   // ← 500!
import "/typecomposer@0.1.56/es2022/global.mjs";
export * from "/typecomposer@0.1.56/es2022/typecomposer.mjs";
```

The generated `core.mjs` returns **HTTP 500** with:
```
esbuild: No matching export in "node_modules/typecomposer/core/index.js" for import "Component"
```

**Why?** `typecomposer`'s `core/index.js` re-exports from sub-packages (`./element`, `./components`, …), and each of those sub-packages re-imports `Component` from `"../.."` (the root). This creates a **circular dependency** that esbuild — used internally by esm.sh — cannot resolve when building its split `core.mjs` entry.

The package has no `"exports"` map and uses `"type": "module"`, so esm.sh tries to split on the bare subpath and fails.

---

## Fix

Switch the import-map URL from `esm.sh` to **jsDelivr `+esm`**:

```ts
// Before (broken):
const typecomposerUrl = `https://esm.sh/typecomposer@${TYPECOMPOSER_VERSION}`;

// After (working):
const typecomposerUrl = `https://cdn.jsdelivr.net/npm/typecomposer@${TYPECOMPOSER_VERSION}/+esm`;
```

jsDelivr's `+esm` endpoint uses **Rollup** to produce a **single flat ES module** from `index.js` directly, bypassing the circular subpath entirely. The result is a 117 KB file with all named exports (`Component`, `VBox`, `DivElement`, `ButtonElement`, etc.) and CORS headers.

| CDN | Response | Notes |
|---|---|---|
| `esm.sh/typecomposer@0.1.56` | 200 stub → imports `core.mjs` → **500** | Circular dep, esbuild chokes |
| `cdn.jsdelivr.net/npm/typecomposer@0.1.56/+esm` | **200, 117 KB** | Rollup single-bundle, all exports present |

---

## Validation

```
# 1. CDN live check (from sandbox)
curl -sI https://cdn.jsdelivr.net/npm/typecomposer@0.1.56/+esm
→ HTTP/2 200, cache-control: public max-age=31536000 immutable, CORS: *

# 2. Named exports present
curl -s ... | grep -o "export{..."
→ export{..., V as Component, pn as HBox, Ge as DivElement, Se as ButtonElement, ...}

# 3. Build result
✓ 3486 modules transformed.
dist/assets/esbuild-BHljloGq.wasm  12,332.68 kB
dist/assets/index-C2_sis7Q.css         48.96 kB
dist/assets/index-Dgoy4g8A.js       1,754.62 kB   ← contains jsdelivr URL (not esm.sh)
✓ built in 15.32s

# 4. No esm.sh URL in dist
grep -r "esm.sh" dist/ → (empty) ✓
```

---

## Files changed

| File | Change |
|---|---|
| `src/views/playground/PlaygroundView.ts` | 1 line: `esm.sh` → `cdn.jsdelivr.net/…/+esm`; updated JSDoc comment |

---

## Manual browser verification still needed

1. Open deployed docs → Playground tab
2. Confirm no `net::ERR_ABORTED 500` in DevTools Network
3. Confirm the demo `AppPage` renders (purple gradient + click button)

cc @zico15 @joaodibba