### PR TITLE
fix(playground): inject in-memory localStorage shim — fixes SecurityError in sandboxed iframe

### DIFF
--- a/src/views/playground/PlaygroundView.ts
+++ b/src/views/playground/PlaygroundView.ts
@@ -249,8 +249,11 @@ export class PlaygroundView extends Component {
 		// Create iframe for preview.
 		// sandbox="allow-scripts": user code runs in a sandboxed context without
 		// access to window.parent, cookies, or the docs page DOM.
-		// allow-same-origin is intentionally omitted — blob: URLs are always
-		// opaque-origin, so omitting it makes the sandbox stricter, not weaker.
+		// allow-same-origin is intentionally omitted — blob: URLs always have an
+		// opaque origin so adding it would have no effect; and without it the
+		// browser blocks localStorage access inside the iframe (SecurityError).
+		// A safe in-memory localStorage shim is injected into the iframe HTML
+		// (see createIframeHTML) so TypeComposer can probe storage without error.
 		this.iframe = previewPanel.appendChild(new IFrameElement({ 
 			className: "flex-1",
 		})) as IFrameElement;
@@ -315,6 +318,11 @@ export class PlaygroundView extends Component {
 	 * The import map resolves `typecomposer` to the jsDelivr CDN (+esm single bundle).
 	 * esm.sh is broken for this package (HTTP 500 on its generated core.mjs due to
 	 * a circular re-export); jsDelivr bundles it correctly with Rollup.
+	 *
+	 * An in-memory localStorage shim is injected before the import map so that
+	 * TypeComposer's runtime can probe storage without throwing a SecurityError in
+	 * the sandboxed iframe (sandbox="allow-scripts" without allow-same-origin blocks
+	 * real localStorage; the shim keeps state within the iframe lifetime only).
 	 */
 	private createIframeHTML(compiledCode: string): string {
 		// jsdelivr +esm bundles the package into a single ES module without the
@@ -334,6 +342,59 @@ export class PlaygroundView extends Component {
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>TypeComposer Preview</title>
+  <script>
+    // In-memory localStorage shim — required because the iframe runs under
+    // sandbox="allow-scripts" without allow-same-origin, which causes the
+    // browser to throw a SecurityError on any localStorage access.
+    // This shim provides a Map-backed storage that behaves like the real API
+    // for the lifetime of the iframe document (not persisted across reloads).
+    (function () {
+      try {
+        // Quick probe: if this succeeds, real localStorage is available.
+        void window.localStorage;
+      } catch (_e) {
+        // Real localStorage is inaccessible — install the in-memory shim.
+        var _store = Object.create(null);
+        var _length = 0;
+        var _shimStorage = {
+          get length() { return _length; },
+          key: function (index) {
+            return Object.keys(_store)[index] !== undefined ? Object.keys(_store)[index] : null;
+          },
+          getItem: function (key) {
+            return Object.prototype.hasOwnProperty.call(_store, key) ? _store[key] : null;
+          },
+          setItem: function (key, value) {
+            if (!Object.prototype.hasOwnProperty.call(_store, key)) _length++;
+            _store[key] = String(value);
+          },
+          removeItem: function (key) {
+            if (Object.prototype.hasOwnProperty.call(_store, key)) {
+              delete _store[key];
+              _length--;
+            }
+          },
+          clear: function () { _store = Object.create(null); _length = 0; }
+        };
+        try {
+          Object.defineProperty(window, 'localStorage', {
+            value: _shimStorage,
+            writable: false,
+            configurable: true
+          });
+          Object.defineProperty(window, 'sessionStorage', {
+            value: _shimStorage,
+            writable: false,
+            configurable: true
+          });
+        } catch (_defineErr) {
+          // Last resort: assign directly (older browsers / CSP edge cases)
+          window.localStorage = _shimStorage;
+          window.sessionStorage = _shimStorage;
+        }
+      }
+    })();
+  </script>
   <script type="importmap">
   {
     "imports": {


### PR DESCRIPTION
## Bug reported by João (post-PR #35)

```
[Playground] Initialization failed: SecurityError: Failed to read the
'localStorage' property from 'Window': The document is sandboxed and
lacks the 'allow-same-origin' flag.
Runtime Error: SecurityError: Failed to read the 'localStorage' property
from 'Window': The document is sandboxed and lacks the 'allow-same-origin' flag.
```

---

## Root cause

PR #34 added `sandbox="allow-scripts"` to the preview `<iframe>` (correct security posture). The browser enforces that a sandboxed document **cannot access `window.localStorage`** unless `allow-same-origin` is also present in the sandbox attribute. TypeComposer's runtime (loaded from jsDelivr, post-PR #35) probes `localStorage` during initialization, which throws a `SecurityError` inside the iframe.

### Why `allow-same-origin` is NOT the fix

The iframe is loaded via a `blob:` URL (see `injectCode()`). Blob URLs **always carry an opaque origin** — they are never same-origin with the parent page. Adding `allow-same-origin` to a blob-loaded iframe:

- Would **not grant access** to the parent page's localStorage (opaque origin = no same-origin relationship).
- Would, however, weaken the sandbox signal and confuse future readers into thinking the iframe is relaxed.
- Adds no benefit since there is no same-origin relationship to exploit.

---

## Fix — in-memory localStorage shim

Inject a tiny IIFE shim as the **first `<script>` tag in `<head>`** (before the importmap), so `window.localStorage` and `window.sessionStorage` are always available when TypeComposer imports.

**Strategy:**
1. `try { void window.localStorage }` — probe real storage.
2. If it throws (SecurityError) → install a `Map`-backed `localStorage`-shaped object via `Object.defineProperty` (or direct assignment as fallback).
3. The shim is **activation-only** — a no-op in environments where real localStorage works.
4. State is ephemeral (iframe lifetime only). This is correct for a preview pane.

```html
<script>
  (function () {
    try {
      void window.localStorage;        // probe — succeeds → skip shim
    } catch (_e) {
      var _store = Object.create(null);
      // ... Map-backed getItem / setItem / removeItem / clear / key / length
      Object.defineProperty(window, 'localStorage', { value: _shimStorage, writable: false, configurable: true });
      Object.defineProperty(window, 'sessionStorage', { value: _shimStorage, writable: false, configurable: true });
    }
  })();
</script>
```

---

## Security analysis

| Approach | Isolation preserved | Fixes error | Notes |
|---|---|---|---|
| Add `allow-same-origin` | ⚠️ Weakens sandbox | ✅ | Wrong: opaque origin means no real-storage access AND weakens sandbox |
| In-memory shim (this PR) | ✅ No change to sandbox | ✅ | Safest: no attribute change, opaque origin preserved, storage scoped to iframe |

The `sandbox="allow-scripts"` attribute is **unchanged**. iframe isolation is **identical** to PR #34.

---

## Files changed

| File | Change |
|---|---|
| `src/views/playground/PlaygroundView.ts` | Shim `<script>` injected before importmap in `createIframeHTML()`; sandbox comment and JSDoc updated |

---

## Build result

```
✓ 3448 modules transformed.
dist/assets/esbuild-BHljloGq.wasm  12,332.68 kB
dist/assets/index-C2_sis7Q.css         48.96 kB
dist/assets/index-BzPRh-vd.js       1,756.71 kB
✓ built in 14.92s
```

Verified in dist:
- ✅ `In-memory localStorage` shim comment present in bundle
- ✅ `SecurityError` shim guard string present
- ✅ `esm.sh` not in bundle
- ✅ jsDelivr URL for typecomposer present
- ✅ `allow-same-origin` appears only inside a comment string (not as attribute)

---

## Manual browser verification still needed

1. Open deployed docs → Playground tab
2. DevTools Console: no `SecurityError` on load
3. DevTools Network: no `esm.sh` requests
4. Playground renders the demo `AppPage` (purple gradient + click button works)

cc @zico15 @joaodibba