### PR TITLE
docs: add Testing guide (Vitest setup, render helper, happy-dom limitations)

### DIFF
--- a/content/testing.mdx
+++ b/content/testing.mdx
@@ -1,0 +1,283 @@
+# Testing
+
+TypeComposer includes a first-class testing setup based on [Vitest](https://vitest.dev) and [happy-dom](https://github.com/capricorn86/happy-dom). All tests live in the `tests/` directory of the core `typecomposer` repository and run directly against TypeScript source — no build step is needed.
+
+---
+
+## Running Tests
+
+Open a terminal in the root of the `typecomposer` repository and run one of the following commands:
+
+| Command | Purpose |
+|---|---|
+| `npm run test` | Start Vitest in **watch mode** — re-runs affected tests on every file save. Use this during development. |
+| `npm run test:run` | **Single non-watch pass** — runs all tests once and exits with code `0` on success or `1` on failure. Use this in CI and before opening a pull request. |
+
+```bash
+# Development — interactive, re-runs on change
+npm run test
+
+# CI / pre-PR validation
+npm run test:run
+```
+
+---
+
+## Test Configuration
+
+Tests are configured in `vitest.config.ts` at the root of the repository:
+
+```ts
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',   // simulated browser DOM
+    globals: true,              // describe / it / expect available globally
+    include: ['tests/**/*.test.ts'],
+    setupFiles: ['./tests/setup.ts'],
+  },
+});
+```
+
+- **`environment: 'happy-dom'`** — every test runs inside a lightweight in-memory DOM. No real browser or `jsdom` is required.
+- **`globals: true`** — `describe`, `it`, `expect`, `vi`, `beforeEach`, and `afterEach` are available without explicit imports.
+- **`setupFiles`** — `tests/setup.ts` is loaded before every test file (see [Setup file](#setup-file) below).
+
+---
+
+## Test Files
+
+```
+tests/
+├── setup.ts                      ← global polyfills and beforeEach hooks
+├── utils.ts                      ← render helper + afterEach cleanup
+├── reactivity.test.ts            ← core ref / observable basics
+├── reactivity-computed.test.ts   ← computed() and derived state
+├── reactive-collections.test.ts  ← RefList, RefMap, RefObject, ref() factory
+├── component.test.ts             ← DivElement, SpanElement rendering smoke tests
+├── composition.test.ts           ← component nesting, HBox / VBox layout
+├── lifecycle.test.ts             ← onConnected, onDisconnected, parent hooks
+├── events.test.ts                ← DOM event binding and propagation
+├── forms.test.ts                 ← CheckBox, TextField, SelectPanel, SwitchPanel
+├── router.test.ts                ← Router.create, navigation, guards
+└── async-components.test.ts      ← ForEach, LazyLoad, VirtualScroll stable tests
+```
+
+---
+
+## Setup File
+
+`tests/setup.ts` is automatically loaded by Vitest before every test file. It does two things:
+
+### 1. MemoryStorage polyfill
+
+happy-dom does not implement the Web Storage API (`localStorage` / `sessionStorage`). The setup file installs a `MemoryStorage` shim so that any framework code or component that reads from or writes to storage works correctly in tests:
+
+```ts
+class MemoryStorage {
+  private data = new Map<string, string>();
+  // implements the full Storage interface
+}
+
+install('localStorage');
+install('sessionStorage');
+```
+
+You do not need to import this file — Vitest loads it automatically.
+
+### 2. Per-test storage reset
+
+A `beforeEach` hook clears both storage stores before every test, so no test can accidentally read state written by a previous one:
+
+```ts
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+});
+```
+
+---
+
+## `render()` Helper
+
+`tests/utils.ts` exports a single `render` helper that every component test should use:
+
+```ts
+import { render } from './utils';
+```
+
+### Signature
+
+```ts
+function render<T extends HTMLElement>(component: T): T
+```
+
+### What it does
+
+1. Appends `component` to `document.body`.
+2. Registers the element in an internal set for cleanup.
+3. Returns the same `component` reference (so it can be used inline).
+
+### Automatic cleanup
+
+`utils.ts` registers an `afterEach` hook that runs after every test and:
+
+1. Removes each registered component from the DOM.
+2. Clears the internal mount registry.
+3. Sets `document.body.innerHTML = ''` as a final reset.
+
+**You do not need to call any cleanup code yourself.** Each test starts with a clean DOM automatically.
+
+### Example
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { DivElement, SpanElement } from '../src';
+import { render } from './utils';
+
+describe('DivElement', () => {
+  it('renders text and is present in the document', () => {
+    const el = render(new DivElement({ text: 'Hello, TypeComposer!' }));
+
+    expect(el).toBeInstanceOf(window.HTMLDivElement);
+    expect(el.textContent).toBe('Hello, TypeComposer!');
+    expect(document.body.contains(el)).toBe(true);
+    // No teardown needed — utils.ts cleans up after the test
+  });
+
+  it('renders styled content', () => {
+    const span = render(new SpanElement({
+      text: 'Styled',
+      style: { color: 'rgb(255, 0, 0)' },
+    }));
+
+    expect(span.style.color).toBe('rgb(255, 0, 0)');
+  });
+});
+```
+
+---
+
+## Recommended Assertion Patterns
+
+### DOM structure
+
+```ts
+// Element is in the document
+expect(document.body.contains(el)).toBe(true);
+
+// Correct element type
+expect(el).toBeInstanceOf(window.HTMLDivElement);
+
+// Text content
+expect(el.textContent).toBe('Hello');
+
+// Child count
+expect(el.childElementCount).toBe(3);
+
+// A specific child
+expect(el.children[0].textContent).toBe('first item');
+
+// Containment
+expect(container.contains(child)).toBe(true);
+```
+
+### Styles
+
+Always use computed / inline-style values (not shorthand color names):
+
+```ts
+expect(el.style.color).toBe('rgb(255, 0, 0)');   // ✓ correct
+expect(el.style.color).toBe('red');               // ✗ may fail in happy-dom
+```
+
+### Reactivity
+
+```ts
+import { ref } from '../src';
+
+const count = ref(0);
+const snapshots: number[] = [];
+
+// subscribe() fires immediately with the current value
+count.subscribe((v) => snapshots.push(v));
+// snapshots = [0]
+
+count.value = 1;
+// snapshots = [0, 1]
+
+// listen() fires only on future changes (not immediately)
+count.listen((v) => console.log(v));
+```
+
+### Async — flushing the microtask queue
+
+When testing code that defers work with `Promise.resolve()` or `queueMicrotask()`, flush pending microtasks before asserting:
+
+```ts
+const flushPromises = () => new Promise<void>((r) => setTimeout(r, 0));
+
+it('loads async content', async () => {
+  const el = render(new LazyLoad({ loader: async () => new DivElement({ text: 'loaded' }) }));
+  el.dispatchEvent(new Event('onConnected'));
+  await flushPromises();
+  // assert after all microtasks have settled
+});
+```
+
+---
+
+## happy-dom Limitations
+
+happy-dom simulates the DOM API but does **not** implement the browser layout engine. The following properties always return `0` or empty values regardless of the styles applied:
+
+| API | happy-dom value | Real browser value |
+|---|---|---|
+| `element.offsetWidth / offsetHeight` | `0` | computed layout |
+| `element.clientWidth / clientHeight` | `0` | computed layout |
+| `element.scrollTop / scrollHeight` | `0` | computed layout |
+| `element.getBoundingClientRect()` | all zeros | computed layout |
+| `IntersectionObserver.entry.isIntersecting` | `false` | depends on viewport |
+
+**Do not write assertions that depend on these values.** Test the logical or structural contract instead:
+
+```ts
+// ✓ Test the child count — always deterministic
+expect(container.childElementCount).toBe(items.length);
+
+// ✓ Test that a style was set programmatically
+expect(el.style.top).toBe('100px');
+
+// ✗ Test that an element is "visible" via offsetHeight > 0
+//   — offsetHeight is always 0 in happy-dom
+```
+
+### Components that are not practically testable under happy-dom
+
+Some components rely on layout or intersection events that have no meaning in happy-dom. For these, add a `describe.skip` block with a comment explaining the limitation and a recipe for an E2E test:
+
+```ts
+describe.skip('VirtualScroll – scroll-position windowing (layout engine required)', () => {
+  /**
+   * SKIPPED: renderVisibleItems() reads this.scrollTop and this.clientHeight.
+   * Both are always 0 in happy-dom.  Add Playwright E2E tests instead:
+   *   1. Mount VirtualScroll with 1000 items in a 200px container.
+   *   2. Set element.scrollTop = 500 and await a paint frame.
+   *   3. Assert that only items near index 10 are in the DOM.
+   */
+  it('renders items centered around scroll position', () => {
+    // placeholder
+  });
+});
+```
+
+---
+
+## Adding New Tests
+
+1. Create `tests/<feature>.test.ts`.
+2. Import framework exports from `'../src'`.
+3. Use `render()` from `'./utils'` for any component that needs to be in the DOM.
+4. Run `npm run test:run` before opening a PR to confirm all tests pass.
+5. If a component cannot be meaningfully tested under happy-dom, add a `describe.skip` block with a comment explaining the limitation and referencing the E2E approach.

--- a/src/assets/data.json
+++ b/src/assets/data.json
@@ -14,6 +14,10 @@
         {
           "title": "Agent Skills",
           "link": "docs/skills"
+        },
+        {
+          "title": "Testing",
+          "link": "docs/testing"
         }
       ]
     },

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -16,6 +16,7 @@ loadDocs().finally(() => {
         children: [
           { path: "getting-started", component: BaseView },
           { path: "skills", component: BaseView },
+          { path: "testing", component: BaseView },
           { path: "components/component", component: BaseView },
           { path: "components/template", component: BaseView },
           { path: "components/lifecycle-docs", component: BaseView },


### PR DESCRIPTION
## Summary

Adds a dedicated **Testing** page to the TypeComposer documentation site, covering everything a contributor or library user needs to know to work with the Vitest + happy-dom test suite introduced in PR #12.

---

## Changed files

| File | Change |
|---|---|
| `content/testing.mdx` | New page — full testing guide |
| `src/router/router.ts` | Register `/docs/testing` route |
| `src/assets/data.json` | Add "Testing" entry in Introduction sidebar section |

---

## Content of `content/testing.mdx`

| Section | What it covers |
|---|---|
| Running Tests | `npm run test` (watch) vs `npm run test:run` (CI/single pass), with code blocks |
| Test Configuration | `vitest.config.ts` annotated — environment, globals, include, setupFiles |
| Test Files | Inventory of every file in `tests/` with a one-line description |
| Setup File | `MemoryStorage` polyfill, `beforeEach` storage clear, auto-loaded via setupFiles |
| `render()` Helper | Signature, what it does, automatic `afterEach` cleanup, full example |
| Assertion Patterns | DOM structure, style values (rgb not named), reactivity, `flushPromises` async helper |
| happy-dom Limitations | Table of APIs that return 0, how to avoid brittle tests, `describe.skip` recipe |
| Adding New Tests | Step-by-step checklist |

---

## Validation

```bash
npm run build
# ✓ built in 17.29s — no errors, no type errors
```

---

## Reviewers

@zico15